### PR TITLE
Add dev instructions and LDAP data persistence

### DIFF
--- a/README.md
+++ b/README.md
@@ -89,3 +89,34 @@ Additionally if a `composer.lock` **and** a `composer.json` are detected, the co
 
 
 Access it via `http://localhost:8080` or `http://host-ip:8080` in a browser.
+
+
+## Setting up instance for development
+
+First startup the application for the first time with:
+
+```bash
+docker-compose up -d
+```
+
+Next after startup run the following to add `the user_cwl_extended_account_data` table
+
+```bash
+docker cp ./dev/add_table.sql mediawiki-docker_db_1:/add_table.sql
+docker exec -it mediawiki-docker_db_1 /bin/bash -c "mysql -u root -ppassword mediawiki < /add_table.sql"
+```
+
+Next you need to uncomment the line `- ./LocalSettings.php:/var/www/html/LocalSettings.php` in the docker compose file.
+
+Finally restart all the containers with:
+
+```bash
+docker-compose down
+docker-compose up -d
+```
+
+## Adding new LDAP users
+
+You can connect to the LDAP container using your preferred LDAP GUI using `localhost:1389` with login `cn=admin,dc=example,dc=org` and password `admin`.
+
+When adding a new user, make sure to use `simpleSecurityObject`, `inetOrgPerson`, and `ubcEdu` classes.

--- a/dev/add_table.sql
+++ b/dev/add_table.sql
@@ -1,0 +1,16 @@
+-- auto-generated definition
+create table user_cwl_extended_account_data
+(
+ ucad_id        int auto_increment                  primary key,
+ user_id        int                                 not null,
+ puid           varchar(50)                         not null,
+ ubc_role_id    int                                 not null,
+ ubc_dept_id    int                                 not null,
+ CWLLogin       varchar(50)                         not null,
+ CWLNickname    varchar(150)                        not null,
+ CWLRole        varchar(120)                        not null,
+ CWLSaltedID    varchar(200)                        not null,
+ wgDBprefix     varchar(150)                        not null,
+ date_created   timestamp default CURRENT_TIMESTAMP not null,
+ account_status varchar(10)                         not null
+);

--- a/dev/ldapadd_ubcedu.ldif
+++ b/dev/ldapadd_ubcedu.ldif
@@ -1,0 +1,29 @@
+dn: cn=ubcedu,cn=schema,cn=config
+objectClass: olcSchemaConfig
+cn: ubcedu
+#
+olcAttributeTypes: (
+    1.3.6.1.4.1.60.1.1.1.1 NAME 'ubcEduCwlPUID'       DESC 'CWL PUID'           EQUALITY caseIgnoreIA5Match SUBSTR caseIgnoreIA5SubstringsMatch SYNTAX 1.3.6.1.4.1.1466.115.121.1.26 SINGLE-VALUE
+    X-ORIGIN 'https://confluence.it.ubc.ca/display/UELE/ubcEdu+Object+Class'
+    )
+olcAttributeTypes: (
+    1.3.6.1.4.1.60.1.1.1.2 NAME 'ubcEduStudentNumber' DESC 'SIS Student Number' EQUALITY caseIgnoreMatch    SUBSTR caseIgnoreSubstringsMatch    SYNTAX 1.3.6.1.4.1.1466.115.121.1.15 SINGLE-VALUE
+    X-ORIGIN 'https://confluence.it.ubc.ca/display/UELE/ubcEdu+Object+Class'
+    )
+olcAttributeTypes: (
+    1.3.6.1.4.1.60.1.1.1.3 NAME 'ubcEduGender'        DESC 'Gender'             EQUALITY caseIgnoreIA5Match SUBSTR caseIgnoreIA5SubstringsMatch SYNTAX 1.3.6.1.4.1.1466.115.121.1.26 SINGLE-VALUE
+    X-ORIGIN 'https://confluence.it.ubc.ca/display/UELE/ubcEdu+Object+Class'
+    )
+olcAttributeTypes: (
+    1.3.6.1.4.1.60.1.1.1.4 NAME 'ubcEduCwlLoginKey'   DESC 'CWL Login Key'      EQUALITY integerMatch                                           SYNTAX 1.3.6.1.4.1.1466.115.121.1.27 SINGLE-VALUE
+    X-ORIGIN 'https://confluence.it.ubc.ca/display/UELE/ubcEdu+Object+Class'
+    )
+olcObjectClasses: (
+    1.3.6.1.4.1.60.1.1.2.1 NAME 'ubcEdu'              DESC 'UBC Specific Attributes'
+    SUP top
+    AUXILIARY
+    MUST ubcEduCwlPUID
+    MAY ( ubcEduCwlLoginKey $ ubcEduGender $ ubcEduStudentNumber )
+    X-ORIGIN 'https://confluence.it.ubc.ca/display/UELE/ubcEdu+Object+Class'
+    )
+

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -23,7 +23,7 @@ services:
     volumes:
       - ./.data/web:/data:rw
       - ./CustomSettings.php:/conf/CustomSettings.php
-      # do not uncomment this when starting a new instance from scratch as 
+      # do not uncomment this when starting a new instance from scratch as
       # init script won't be able to move this file
       #- ./LocalSettings.php:/var/www/html/LocalSettings.php
     environment:
@@ -38,9 +38,12 @@ services:
       - PARSOID_URL=http://nodeservices:8142
       - PARSOID_DOMAIN=localhost
       - RESTBASE_URL=http://nodeservices:7231
+      - LDAP_DOMAIN=CWL
+      - LDAP_SERVER=ldap
       - LDAP_SEARCH_ATTRS=cn
       - LDAP_PROXY_AGENT=cn=admin,dc=example,dc=org
       - LDAP_PROXY_PASSWORD=admin
+      - LDAP_BASE_DN=dc=example,dc=org
       #- MEDIAWIKI_MAIN_CACHE=CACHE_MEMCACHED
       - MEDIAWIKI_MAIN_CACHE=CACHE_NONE
       #- MEDIAWIKI_MEMCACHED_SERVERS=["memcached:11211"]
@@ -87,5 +90,12 @@ services:
       - ./.data/services:/data
   ldap:
     image: osixia/openldap:1.1.9
+    command: --copy-service
+    ports:
+      - 1389:389
+    volumes:
+      - ./dev/ldapadd_ubcedu.ldif:/container/service/slapd/assets/config/bootstrap/ldif/custom/ldapadd_ubcedu.ldif
+      - ./.data/ldap:/var/lib/ldap
+      - ./.data/slapd.d:/etc/ldap/slapd.d
   memcached:
     image: memcached:1.5-alpine


### PR DESCRIPTION
- `ldapadd_ubcedu.ldif` will automatically be run when  ldap container run for the first time adding ubcedu ldap class info (requires `--copy-service` argument added to the entrypoint so that it will work without issue on subsequent startups)
- Data will also be persisted by default by adding external volumes to the `/var/lib/ldap` and `/etc/ldap/slapd.d` directories
- added sql file for adding the `user_cwl_extended_account_data` table