### PR TITLE
Add caliper support

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -73,7 +73,9 @@ RUN curl -L https://extdist.wmflabs.org/dist/skins/Vector-${VECTOR_SKIN_VERSION}
     && mkdir -p /var/www/html/extensions/Widgets/smarty \
     && curl -Ls https://github.com/smarty-php/smarty/archive/v3.1.30.tar.gz | tar xz --strip=1 -C /var/www/html/extensions/Widgets/smarty \
     && mkdir -p /var/www/html/extensions/GoogleAnalyticsMetrics \
-    && curl -Ls https://github.com/wikimedia/mediawiki-extensions-GoogleAnalyticsMetrics/archive/master.tar.gz | tar xz --strip=1 -C /var/www/html/extensions/GoogleAnalyticsMetrics
+    && curl -Ls https://github.com/wikimedia/mediawiki-extensions-GoogleAnalyticsMetrics/archive/master.tar.gz | tar xz --strip=1 -C /var/www/html/extensions/GoogleAnalyticsMetrics \
+    && mkdir -p /var/www/html/extensions/caliper \
+    && curl -Ls https://github.com/ubc/mediawiki-extensions-caliper/archive/master.tar.gz | tar xz --strip=1 -C /var/www/html/extensions/caliper
 
 RUN mkdir -p /data \
    && chmod a+x /var/www/html/extensions/Scribunto/engines/LuaStandalone/binaries/lua5_1_5_linux_64_generic/lua \

--- a/LocalSettings.php
+++ b/LocalSettings.php
@@ -51,6 +51,9 @@ $wgEnableUserEmail = filter_var(loadenv('MEDIAWIKI_ENABLE_USER_EMAIL', true), FI
 $wgEmergencyContact = loadenv('MEDIAWIKI_EMERGENCY_CONTACT', "apache@localhost");
 $wgPasswordSender = loadenv('MEDIAWIKI_PASSWORD_SENDER', "apache@localhost");
 
+# Disable Job execution on page requests (can be setup via cron jobs)
+$wgJobRunRate = 0;
+
 $wgEnotifUserTalk = false; # UPO
 $wgEnotifWatchlist = true; # UPO
 $wgEmailAuthentication = true;
@@ -520,6 +523,13 @@ if (getenv('MEDIAWIKI_EXTENSIONS') && strpos(getenv('MEDIAWIKI_EXTENSIONS'), 'go
     $wgGoogleAnalyticsMetricsAllowed = $t == '*' ? '*' : explode(',', $t);
     $wgGoogleAnalyticsMetricsPath = loadenv('GOOGLE_ANALYTICS_METRICS_PATH', NULL);
     $wgGoogleAnalyticsMetricsViewId = loadenv('GOOGLE_ANALYTICS_METRICS_VIEWID', '');
+}
+
+# setup caliper settings if enabled
+if (getenv('MEDIAWIKI_EXTENSIONS') && strpos(getenv('MEDIAWIKI_EXTENSIONS'), 'caliper') !== false && loadenv('CaliperHost') && loadenv('CaliperAPIKey')) {
+    $wgCaliperHost = loadenv('CaliperHost');
+    $wgCaliperAPIKey = loadenv('CaliperAPIKey');
+    $wgCaliperAppBaseUrl = loadenv('CaliperAppBaseUrl', null);
 }
 
 @include('/conf/CustomSettings.php');

--- a/README.md
+++ b/README.md
@@ -120,3 +120,11 @@ docker-compose up -d
 You can connect to the LDAP container using your preferred LDAP GUI using `localhost:1389` with login `cn=admin,dc=example,dc=org` and password `admin`.
 
 When adding a new user, make sure to use `simpleSecurityObject`, `inetOrgPerson`, and `ubcEdu` classes.
+
+## Custom Caliper actor data
+
+See the [mediawiki-extensions-caliper](https://github.com/ubc/mediawiki-extensions-caliper/blob/master/caliper/actor.php) repo's `CaliperActor` object for the default logged in and logged out users.
+
+You can customize the Caliper actor by using the `SetCaliperActorObject` hook. This container has uses this hook with the `SetCaliperActor` function inside of `CustomHooks.php`.
+
+By default, the `SetCaliperActor` function will use UBC `puid` for the identifier and `CaliperLDAPActorHomepage` environment variable as the base string so the actor identifier will take the form of `CaliperLDAPActorHomepage/LDAP_PUID` (ex: `https://www.ubc.ca/SOME_PUID`). you can instead remove this function and create your own depending on your institution needs, deployment settings, and/or authorization methods.

--- a/composer.local.json
+++ b/composer.local.json
@@ -7,6 +7,7 @@
         "pear/mail_mime": "1.10.2",
         "pear/mail_mime-decode": "1.5.5.2",
         "pear/net_smtp": "1.7.3",
-        "google/apiclient":"^2.0"
+        "google/apiclient":"^2.0",
+        "imsglobal/caliper": "1.1.0"
     }
 }

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -33,7 +33,7 @@ services:
       - MEDIAWIKI_DB_PASSWORD=password
       # uncomment 'MEDIAWIKI_ENABLE_SSL' to enable SSL support
       # - MEDIAWIKI_ENABLE_SSL=true
-      - MEDIAWIKI_EXTENSIONS=VisualEditor,WikiEditor,ParserFunctions,Cite,TemplateData,Scribunto,InputBox,Widgets,Maps,Math,LiquidThreads,Variables,RightFunctions,PageInCat,CategoryTree,LabeledSectionTransclusion,UserPageEditProtection,Quiz,UploadWizard,Collection,DynamicPageList,EmbedPage,UWUBCMessages,GoogleAnalyticsMetrics,googleAnalytics,Renameuser
+      - MEDIAWIKI_EXTENSIONS=VisualEditor,WikiEditor,ParserFunctions,Cite,TemplateData,Scribunto,InputBox,Widgets,Maps,Math,LiquidThreads,Variables,RightFunctions,PageInCat,CategoryTree,LabeledSectionTransclusion,UserPageEditProtection,Quiz,UploadWizard,Collection,DynamicPageList,EmbedPage,UWUBCMessages,GoogleAnalyticsMetrics,googleAnalytics,Renameuser,caliper
       - MEDIAWIKI_ALLOW_SITE_CSS_ON_RESTRICTED_PAGES=true
       - PARSOID_URL=http://nodeservices:8142
       - PARSOID_DOMAIN=localhost
@@ -65,6 +65,10 @@ services:
       #- GOOGLE_ANALYTICS_METRICS_PATH
       #- GOOGLE_ANALYTICS_METRICS_VIEWID
       - DEBUG=true
+      # - CaliperHost=https://caliper.imsglobal.org/caliper/PUT_TEST_BEARER_TOKEN_HERE/message
+      # - CaliperAPIKey=PUT_TEST_BEARER_TOKEN_HERE
+      # - CaliperAppBaseUrl=http://localhost:8888/test_url/
+      # - CaliperLDAPActorHomepage=http://media_wiki_ldap_homepage
 
 # use combined image for now
 #  parsoid:


### PR DESCRIPTION
- Load `CaliperHost`, `CaliperAPIKey`, and `CaliperAppBaseUrl` in LocalSetting.php
- Added `SetCaliperActorObject` hook in CustomHook.php. Will set the Caliper actor using ldap user info stored in the `user_cwl_extended_account_data` table
- `CaliperLDAPActorHomepage` environment variable should be set so that `SetCaliperActorObject` hook can set the proper homepage
- Added `$wgJobRunRate = 0;` to LocalSetting.php in order to set the job queue to cron mode (need to add a cron job that will run `php maintenance/runJobs.php`)

Note: currently the caliper php library create a lot of notices when sending events. There is a PR to fix it here: IMSGlobal/caliper-php#327