### PR TITLE
Update Caliper version

### DIFF
--- a/composer.local.json
+++ b/composer.local.json
@@ -3,13 +3,13 @@
     "repositories": [
         {
             "type": "git",
-            "url": "https://github.com/IMSGlobal/caliper-php.git"
+            "url": "https://github.com/IMSGlobal/caliper-php"
         }
     ],
     "require": {
         "mediawiki/maps": "~6.0",
         "pear/mail_mime-decode": "1.5.5.2",
         "google/apiclient":"^2.2",
-        "imsglobal/caliper": "1.1.0"
+        "imsglobal/caliper": "dev-develop#c7e34e230abc7bbb647f8f94245cb649f6191bcd as 1.2.0"
     }
 }


### PR DESCRIPTION
Should wait until until next `caliper-php` release (which will include the resource management profile)

Related to https://github.com/ubc/mediawiki-extensions-caliper/pull/1