### PR TITLE
Explicitly specify the caliper-php repo

### DIFF
--- a/composer.local.json
+++ b/composer.local.json
@@ -1,5 +1,11 @@
 {
     "minimum-stability": "stable",
+    "repositories": [
+        {
+            "type": "git",
+            "url": "https://github.com/IMSGlobal/caliper-php.git"
+        }
+    ],
     "require": {
         "mediawiki/maps": "~6.0",
         "pear/mail_mime-decode": "1.5.5.2",


### PR DESCRIPTION
- the original caliper-php-public repo has been deprecated in favor of
caliper-php. Until the composer repository is updated, need to
explicitly specify the repo.

Similar change as PR #9, but we are not changing the caliper version
here. Only specify the repo so that the docker image can be built