### PR TITLE
Migrate to LDAPAuthentication2

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -49,6 +49,7 @@ RUN echo "Include /etc/apache2/mediawiki.conf" >> /etc/apache2/apache2.conf \
     && a2enmod remoteip
 
 COPY docker-entrypoint.sh /entrypoint.sh
+COPY docker-startuptasks.sh /startuptasks.sh
 COPY LocalSettings.php /var/www/html/LocalSettings.php
 COPY CustomHooks.php /var/www/html/CustomHooks.php
 COPY composer.local.json /var/www/html/composer.local.json

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM php:7.1-apache
+FROM php:7.3-apache
 
 ENV WIKI_VERSION_MAJOR_MINOR=1.31
 ENV WIKI_VERSION_BUGFIX=7
@@ -59,7 +59,7 @@ RUN curl -L https://getcomposer.org/installer | php \
 
 RUN curl -L https://extdist.wmflabs.org/dist/skins/Vector-${VECTOR_SKIN_VERSION}.tar.gz | tar xz -C /var/www/html/skins \
     && EXTS=`curl https://extdist.wmflabs.org/dist/extensions/ | awk 'BEGIN { FS = "\""  } ; {print $2}'` \
-    && for i in VisualEditor Scribunto LiquidThreads Cite WikiEditor LdapAuthentication ParserFunctions TemplateData InputBox Widgets Math Variables RightFunctions PageInCat CategoryTree LabeledSectionTransclusion UserPageEditProtection Quiz Collection DynamicPageList googleAnalytics DeleteBatch LinkTarget; do \
+    && for i in VisualEditor Scribunto LiquidThreads Cite WikiEditor LDAPProvider PluggableAuth LDAPAuthentication2 ParserFunctions TemplateData InputBox Widgets Math Variables RightFunctions PageInCat CategoryTree LabeledSectionTransclusion UserPageEditProtection Quiz Collection DynamicPageList googleAnalytics DeleteBatch LinkTarget; do \
       FILENAME=`echo "$EXTS" | grep ^${i}-REL${WIKI_VERSION_STR}`; \
       echo "Installing https://extdist.wmflabs.org/dist/extensions/$FILENAME"; \
       curl -Ls https://extdist.wmflabs.org/dist/extensions/$FILENAME | tar xz -C /var/www/html/extensions; \

--- a/README.md
+++ b/README.md
@@ -28,14 +28,16 @@ Use the following environmental variables to generate a `LocalSettings.php` and 
  - `-e LDAP_DOMAIN` (defaults not set, LDAP domain, e.g. CWL)
  - `-e LDAP_SERVER` (defaults not set, LDAP server address)
  - `-e LDAP_PORT` (defaults to `389`, LDAP server port)
- - `-e LDAP_ENCRYPTION_TYPE` (defaults to `clear`, LDAP connection encryption type, possible values are `clear`, `tls` and `ssl`)
- - `-e LDAP_AUTO_CREATE` (defaults to `false`, auto create user account if not in MediaWiki)
- - `-e LDAP_BASE_DN` (defaults to `ou=Users,ou=LOCAL,dc=domain,dc=local`, LDAP base DN)
+ - `-e LDAP_ENCRYPTION_TYPE` (defaults to `clear`, LDAP connection encryption type, possible values are `clear`, `ldapi`, `tls` and `ssl`)
+ - `-e LDAP_BASE_DN` (defaults to `ou=Users,ou=LOCAL,dc=domain,dc=local`, LDAP base DN for searching)
+ - `-e LDAP_USER_BASE_DN` (defaults to `ou=Users,ou=LOCAL,dc=domain,dc=local`, LDAP base DN for user info)
  - `-e LDAP_SEARCH_STRINGS` (defaults not set, LDAP search string)
  - `-e LDAP_SEARCH_ATTRS` (defaults not set, LDAP search attribute)
  - `-e LDAP_PROXY_AGENT` (defaults not set, LDAP proxy agent)
  - `-e LDAP_PROXY_PASSWORD` (defaults not set, LDAP proxy agent password)
- - `-e LDAP_DEBUG` (defaults to `0`, LDAP debug level, debug file is located /tmp/mw_ldap_debug.log)
+ - `-e LDAP_USERNAME_ATTR` (defaults to `cn`, LDAP attribute for user name)
+ - `-e LDAP_REALNAME_ATTR` (defaults to `displayname`, LDAP attribute for real name)
+ - `-e LDAP_EMAIL_ATTR` (defaults to `mail`, LDAP attribute for for email address)
  - `-e MEDIAWIKI_MAIN_CACHE` (defaults to `CACHE_NONE`, main cache)
  - `-e MEDIAWIKI_MEMCACHED_SERVERS` (defaults to `[]`, list of memcched servers, comma separated, e.g.["memcached:11211", "memcached1:11211"])
 
@@ -120,6 +122,12 @@ docker-compose up -d
 You can connect to the LDAP container using your preferred LDAP GUI using `localhost:1389` with login `cn=admin,dc=example,dc=org` and password `admin`.
 
 When adding a new user, make sure to use `simpleSecurityObject`, `inetOrgPerson`, and `ubcEdu` classes.
+
+## Customizing the login page with LDAP authentication enabled
+
+Customize the login button by modifying the page `MediaWiki:Pluggableauth-loginbutton-label`.  The default is "Log in with PluggableAuth".
+
+Customize the login help message by modifying the page `MediaWiki:Userlogin-helplink2`.  The default is a hyperlink "Help with logging in" that links to mediawiki help page.
 
 ## Custom Caliper actor data
 

--- a/README.md
+++ b/README.md
@@ -127,7 +127,7 @@ When adding a new user, make sure to use `simpleSecurityObject`, `inetOrgPerson`
 
 Customize the login button by modifying the page `MediaWiki:Pluggableauth-loginbutton-label`.  The default is "Log in with PluggableAuth".
 
-Customize the login help message by modifying the page `MediaWiki:Userlogin-helplink2`.  The default is a hyperlink "Help with logging in" that links to mediawiki help page.
+Customize the login help message by modifying the page `MediaWiki:Userlogin-helplink2` and `MediaWiki:Helplogin-url`.  The default is a hyperlink "Help with logging in" that links to mediawiki help page.
 
 ## Custom Caliper actor data
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -27,7 +27,7 @@ services:
       # init script won't be able to move this file
       #- ./LocalSettings.php:/var/www/html/LocalSettings.php
     environment:
-      - MEDIAWIKI_SITE_SERVER=//localhost:8080
+      - MEDIAWIKI_SITE_SERVER=http://localhost:8080
       - MEDIAWIKI_SITE_NAME=My Awesome Wiki
       - MEDIAWIKI_DB_HOST=db
       - MEDIAWIKI_DB_PASSWORD=password
@@ -40,25 +40,20 @@ services:
       - RESTBASE_URL=http://nodeservices:7231
       - LDAP_DOMAIN=CWL
       - LDAP_SERVER=ldap
+      - LDAP_ENCRYPTION_TYPE=clear
       - LDAP_SEARCH_ATTRS=cn
       - LDAP_PROXY_AGENT=cn=admin,dc=example,dc=org
       - LDAP_PROXY_PASSWORD=admin
       - LDAP_BASE_DN=dc=example,dc=org
+      - LDAP_USER_BASE_DN=dc=example,dc=org
+      - LDAP_USERNAME_ATTR=cn
+      - LDAP_REALNAME_ATTR=displayname
+      - LDAP_EMAIL_ATTR=mail
       #- MEDIAWIKI_MAIN_CACHE=CACHE_MEMCACHED
       - MEDIAWIKI_MAIN_CACHE=CACHE_NONE
       #- MEDIAWIKI_MEMCACHED_SERVERS=["memcached:11211"]
       # uncomment to specify the wgUploadPath
       # - MEDIAWIKI_UPLOAD_PATH=
-      - LDAP_DEBUG=3
-      # the following variables are from shell environment or .env file
-      #- LDAP_SERVER
-      #- LDAP_PORT
-      #- LDAP_DOMAIN
-      #- LDAP_BASE_DN
-      #- LDAP_SEARCH_ATTRS
-      #- LDAP_PROXY_AGENT
-      #- LDAP_PROXY_PASSWORD
-      #- LDAP_ENCRYPTION_TYPE
       #- GOOGLE_ANALYTICS_UA=UA-XXXXXXX-XX
       # GoogleAnalyticsMetrics: https://www.mediawiki.org/wiki/Extension:GoogleAnalyticsMetrics
       #- GOOGLE_ANALYTICS_METRICS_ALLOWED

--- a/docker-entrypoint.sh
+++ b/docker-entrypoint.sh
@@ -7,7 +7,6 @@ set -e
 : ${MEDIAWIKI_ADMIN_USER:=admin}
 : ${MEDIAWIKI_ADMIN_PASS:=admin1234}
 : ${MEDIAWIKI_DB_TYPE:=mysql}
-: ${MEDIAWIKI_DB_SCHEMA:=mediawiki}
 : ${MEDIAWIKI_ENABLE_SSL:=false}
 : ${MEDIAWIKI_UPDATE:=false}
 
@@ -175,7 +174,6 @@ if [ ! -e "$MEDIAWIKI_SHARED/installed" -a ! -f "$MEDIAWIKI_SHARED/install.lock"
 	php maintenance/install.php \
 		--confpath /var/www/html \
 		--dbname "$MEDIAWIKI_DB_NAME" \
-		--dbschema "$MEDIAWIKI_DB_SCHEMA" \
 		--dbport "$MEDIAWIKI_DB_PORT" \
 		--dbserver "$MEDIAWIKI_DB_HOST" \
 		--dbtype "$MEDIAWIKI_DB_TYPE" \
@@ -227,6 +225,10 @@ if [ -e "LocalSettings.php" -a "$MEDIAWIKI_UPDATE" = 'true' -a ! -f "$MEDIAWIKI_
 	php maintenance/update.php --quick --conf ./LocalSettings.php
     rm $MEDIAWIKI_SHARED/update.lock
 fi
+
+# Run custom startup tasks
+chmod 755 /startuptasks.sh
+/startuptasks.sh
 
 # Ensure images folder exists
 mkdir -p images

--- a/docker-startuptasks.sh
+++ b/docker-startuptasks.sh
@@ -1,0 +1,12 @@
+#!/bin/bash
+
+set -e
+
+# Create template for DPL extension.  If the page doesn't exist, the extension
+# will redirect the fist login user to edit page.  This breaks the LDAP
+# authentication flow.
+: ${DPL_TEMPLATE_TITLE:='Template:Extension_DPL'}
+php /var/www/html/maintenance/getText.php "$DPL_TEMPLATE_TITLE" > /dev/null 2>&1 || 
+    (echo >&2 "Generating DPL template $DPL_TEMPLATE_TITLE" && 
+     echo "<noinclude>This page was automatically created. It serves as an anchor page for all '''[[Special:WhatLinksHere/Template:Extension_DPL|invocations]]''' of [http://mediawiki.org/wiki/Extension:DynamicPageList Extension:DynamicPageList (DPL)].</noinclude>" | php /var/www/html/maintenance/edit.php -s "Template for DPL" "$DPL_TEMPLATE_TITLE" 
+    )


### PR DESCRIPTION
- replace LDAPAuthentication with
  LDAPAuthentication2+LDAPProvider+PluggableAuth
- use the LDAP username normalizer as a hook to transform LDAP username
  to wiki username
- no need to do backward transformation from wiki -> LDAP username
- upgrade to PHP 7.3 (7.1 has reached EOL and mediawiki is not
  compatible with some versions of 7.4)

Closes #8 